### PR TITLE
Added hashing for IP addresses and visual additions

### DIFF
--- a/index.php
+++ b/index.php
@@ -5,7 +5,8 @@
     $password = "pass";
 
     // Exchanges in DB:
-    // Binance      1
+    // Binance.COM  1
+    // Binance.US   8
     // Bitfinex     2
     // Bitvavo      3
     // bitpanda     4
@@ -42,7 +43,7 @@
         if($count == 0) {
             $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '1', '0')";
             if($conn->query($sql) === TRUE) {
-                $voteMessage = "You voted for Binance withdrawals being suspended!";
+                $voteMessage = "You voted for Binance COM withdrawals being suspended!";
             } else {
                 $voteMessage = "There was an issue with the database.";
             }
@@ -56,7 +57,7 @@
         if($count == 0) {
             $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '1', '1')";
             if($conn->query($sql) === TRUE) {
-                $voteMessage = "You voted for Binance withdrawals being possible!";
+                $voteMessage = "You voted for Binance withdrawals COM being possible!";
             } else {
                 $voteMessage = "There was an issue with the database.";
             }
@@ -231,6 +232,34 @@
         } else {
             $voteMessage = "You already voted in the last 24 hours!";
         }
+    } elseif(isset($_POST['binanceusup'])) {
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 8";
+        $result = mysqli_query($conn, $sql);
+        $count = mysqli_num_rows($result);
+        if($count == 0) {
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '8', '1')";
+            if($conn->query($sql) === TRUE) {
+                $voteMessage = "You voted for Binance US withdrawals being possible!";
+            } else {
+                $voteMessage = "There was an issue with the database.";
+            }
+        } else {
+            $voteMessage = "You already voted in the last 24 hours!";
+        }
+    } elseif(isset($_POST['binanceusdown'])) {
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 8";
+        $result = mysqli_query($conn, $sql);
+        $count = mysqli_num_rows($result);
+        if($count == 0) {
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '8', '0')";
+            if($conn->query($sql) === TRUE) {
+                $voteMessage = "You voted for Binance US withdrawals being suspended!";
+            } else {
+                $voteMessage = "There was an issue with the database.";
+            }
+        } else {
+            $voteMessage = "You already voted in the last 24 hours!";
+        }
     }
 
     function get_percentage($total, $number) {
@@ -264,12 +293,8 @@
 
         </div>
             <div class=content>
-            <section id="binance">
-                <h2><a href="https://www.binance.com">Binance</a></h2>
-                <form method="post">
-                    <input type="submit" name="binanceup" value="Withdrawal possible" style="background-color: #52B788">
-                    <input type="submit" name="binancedown" value="Withdrawal suspended" style="background-color: #E63946">
-                </form>
+            <section id="binance-com">
+                <h2><a href="https://www.binance.com">Binance.com</a></h2>
                 <p>
                     <?php 
                         $sql = "SELECT * FROM votes WHERE Exchange = 1 AND Status = 0";
@@ -293,14 +318,47 @@
                         }
                     ?>
                 </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="binanceup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="binancedown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
+            </section>
+
+            <section id="binance-us">
+                <h2><a href="https://www.binance.us">Binance.us</a></h2>
+                <p>
+                    <?php 
+                        $sql = "SELECT * FROM votes WHERE Exchange = 8 AND Status = 0";
+                        $result = mysqli_query($conn, $sql);
+                        $downCount = mysqli_num_rows($result);
+                        echo $downCount;
+                    ?> votes for suspended withdrawals in the last 24 hours.<br>
+                    <?php
+                        $sql = "SELECT * FROM votes WHERE Exchange = 8 AND Status = 1";
+                        $result = mysqli_query($conn, $sql);
+                        $upCount = mysqli_num_rows($result);
+                        echo $upCount;
+                    ?> votes for possible withdrawals in the last 24 hours.<br>
+                    <?php
+                    // Check how many percent of users voted for suspended withdrawals
+                        $total = $downCount + $upCount;
+                        $percentage = get_percentage($total, $downCount);
+                        echo "<br>Therefore, $percentage% voted for suspended withdrawals in the last 24 hours.<br>";
+                        if($percentage >= 20) {
+                            echo '<br><span style="color: #FFBF00; font-weight:500;">It is likely that withdrawals are suspended at the moment, because more than 20% voted for suspended withdrawals!</span>';
+                        }
+                    ?>
+                </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="binanceusup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="binanceusdown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
             </section>
             
             <section id="bitfinex">
                 <h2><a href="https://www.bitfinex.com/">Bitfinex</a></h2>
-                <form method="post">
-                    <input type="submit" name="bitfinexup" value="Withdrawal possible" style="background-color: #52B788">
-                    <input type="submit" name="bitfinexdown" value="Withdrawal suspended" style="background-color: #E63946">
-                </form>
                 <p>
                     <?php 
                         $sql = "SELECT * FROM votes WHERE Exchange = 2 AND Status = 0";
@@ -324,14 +382,15 @@
                         }
                     ?>
                 </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="bitfinexup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="bitfinexdown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
             </section>
 
             <section id="bitvavo">
                 <h2><a href="https://bitvavo.com">Bitvavo</a></h2>
-                <form method="post">
-                    <input type="submit" name="bitvavoup" value="Withdrawal possible" style="background-color: #52B788">
-                    <input type="submit" name="bitvavodown" value="Withdrawal suspended" style="background-color: #E63946">
-                </form>
                 <p>
                     <?php 
                         $sql = "SELECT * FROM votes WHERE Exchange = 3 AND Status = 0";
@@ -355,14 +414,15 @@
                         }
                     ?>
                 </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="bitvavoup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="bitvavodown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
             </section>
 
             <section id="bitpanda">
                 <h2><a href="https://www.bitpanda.com">bitpanda</a></h2>
-                <form method="post">
-                    <input type="submit" name="bitpandaup" value="Withdrawal possible" style="background-color: #52B788">
-                    <input type="submit" name="bitpandadown" value="Withdrawal suspended" style="background-color: #E63946">
-                </form>
                 <p>
                     <?php 
                         $sql = "SELECT * FROM votes WHERE Exchange = 4 AND Status = 0";
@@ -386,14 +446,15 @@
                         }
                     ?>
                 </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="bitpandaup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="bitpandadown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
             </section>
 
             <section id="upbit">
                 <h2><a href="https://upbit.com">Upbit</a></h2>
-                <form method="post">
-                    <input type="submit" name="upbitup" value="Withdrawal possible" style="background-color: #52B788">
-                    <input type="submit" name="upbitdown" value="Withdrawal suspended" style="background-color: #E63946">
-                </form>
                 <p>
                     <?php 
                         $sql = "SELECT * FROM votes WHERE Exchange = 5 AND Status = 0";
@@ -417,14 +478,15 @@
                         }
                     ?>
                 </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="upbitup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="upbitdown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
             </section>
 
             <section id="indodax">
                 <h2><a href="https://indodax.com/">Indodax</a></h2>
-                <form method="post">
-                    <input type="submit" name="indodaxup" value="Withdrawal possible" style="background-color: #52B788">
-                    <input type="submit" name="indodaxdown" value="Withdrawal suspended" style="background-color: #E63946">
-                </form>
                 <p>
                     <?php 
                         $sql = "SELECT * FROM votes WHERE Exchange = 6 AND Status = 0";
@@ -448,14 +510,15 @@
                         }
                     ?>
                 </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="indodaxup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="indodaxdown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
             </section>
 
             <section id="kucoin">
                 <h2><a href="https://www.kucoin.com/">KuCoin</a></h2>
-                <form method="post">
-                    <input type="submit" name="kucoinup" value="Withdrawal possible" style="background-color: #52B788">
-                    <input type="submit" name="kucoindown" value="Withdrawal suspended" style="background-color: #E63946">
-                </form>
                 <p>
                     <?php 
                         $sql = "SELECT * FROM votes WHERE Exchange = 7 AND Status = 0";
@@ -479,6 +542,11 @@
                         }
                     ?>
                 </p>
+                <p>Have you withdrawn recently? If so, please vote:</p>
+                <form method="post">
+                    <input type="submit" name="kucoinup" value="Withdrawal possible" style="background-color: #52B788">
+                    <input type="submit" name="kucoindown" value="Withdrawal suspended" style="background-color: #E63946">
+                </form>
             </section>
         </div>
         <div class="footer">

--- a/index.php
+++ b/index.php
@@ -555,6 +555,7 @@
                 <b>IOTA Donation address:</b><br>
                 iota1qqm9k3003sszpq4d5n0yc89pk6dvpm3wvc7lexlzr2nwwrpaxaxdg7f85k6<br><br>
                 Developed by <a href="https://github.com/braydofficial">thisdudeisvegan</a><br>
+                Source on <a href="https://github.com/braydofficial/iotaexchangestatus">GitHub</a><br>
             </p>
         </div>
     </body>

--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@
     $userIP = $_SERVER['REMOTE_ADDR'];
     $IPSalt = "SALT"; // Change to set custom salt to protect IP addresses in case of database breach
     $IPConcat = "$userIP$IPSalt";
-    $userIPHashed = md5($IPConcat);
+    $userIPHashed = hash("sha256", $IPConcat);
 
     // create connection
     $conn = mysqli_connect($host, $username, $password, $database);
@@ -36,11 +36,11 @@
 
     // Check POST methods to track votes
     if(isset($_POST['binancedown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '1', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '1', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Binance withdrawals being suspended!";
             } else {
@@ -50,11 +50,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif (isset($_POST['binanceup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '1', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '1', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Binance withdrawals being possible!";
             } else {
@@ -64,11 +64,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '2', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '2', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitfinex withdrawals being possible!";
             } else {
@@ -78,11 +78,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '2', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '2', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitfinex withdrawals being suspended!";
             } else {
@@ -92,11 +92,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavoup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '3', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '3', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitvavo withdrawals being possible!";
             } else {
@@ -106,11 +106,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavodown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '3', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '3', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitvavo withdrawals being suspended!";
             } else {
@@ -120,11 +120,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandaup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '4', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '4', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for bitpanda withdrawals being possible!";
             } else {
@@ -134,11 +134,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandadown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '4', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '4', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for bitpanda withdrawals being suspended!";
             } else {
@@ -148,11 +148,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '5', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '5', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Upbit withdrawals being possible!";
             } else {
@@ -162,11 +162,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '5', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '5', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Upbit withdrawals being suspended!";
             } else {
@@ -176,11 +176,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '6', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '6', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Indodax withdrawals being possible!";
             } else {
@@ -190,11 +190,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '6', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '6', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Indodax withdrawals being suspended!";
             } else {
@@ -204,11 +204,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoinup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '7', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '7', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for KuCoin withdrawals being possible!";
             } else {
@@ -218,11 +218,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoindown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = '$userIPHashed' AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '7', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, '$userIPHashed', '7', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for KuCoin withdrawals being suspended!";
             } else {

--- a/index.php
+++ b/index.php
@@ -22,6 +22,8 @@
     $voteMessage = "";
 
     $userIP = $_SERVER['REMOTE_ADDR'];
+    $userIPHashed = password_hash($userIP, PASSWORD_DEFAULT);
+    $userIPHashedResult = password_verify($userIP, $userIPHashed);
 
     // create connection
     $conn = mysqli_connect($host, $username, $password, $database);
@@ -33,11 +35,11 @@
 
     // Check POST methods to track votes
     if(isset($_POST['binancedown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '1', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '1', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Binance withdrawals being suspended!";
             } else {
@@ -47,11 +49,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif (isset($_POST['binanceup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '1', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '1', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Binance withdrawals being possible!";
             } else {
@@ -61,11 +63,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '2', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '2', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitfinex withdrawals being possible!";
             } else {
@@ -75,11 +77,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '2', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '2', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitfinex withdrawals being suspended!";
             } else {
@@ -89,11 +91,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavoup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '3', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '3', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitvavo withdrawals being possible!";
             } else {
@@ -103,11 +105,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavodown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '3', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '3', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Bitvavo withdrawals being suspended!";
             } else {
@@ -117,11 +119,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandaup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '4', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '4', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for bitpanda withdrawals being possible!";
             } else {
@@ -131,11 +133,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandadown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '4', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '4', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for bitpanda withdrawals being suspended!";
             } else {
@@ -145,11 +147,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '5', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '5', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Upbit withdrawals being possible!";
             } else {
@@ -159,11 +161,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '5', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '5', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Upbit withdrawals being suspended!";
             } else {
@@ -173,11 +175,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '6', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '6', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Indodax withdrawals being possible!";
             } else {
@@ -187,11 +189,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '6', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '6', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for Indodax withdrawals being suspended!";
             } else {
@@ -201,11 +203,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoinup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '7', '1')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '7', '1')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for KuCoin withdrawals being possible!";
             } else {
@@ -215,11 +217,11 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoindown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = INET_ATON('$userIP') AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
-            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, INET_ATON('$userIP'), '7', '0')";
+            $sql = "INSERT INTO `votes` (`ID`, `IP`, `Exchange`, `Status`) VALUES (NULL, $userIPHashed, '7', '0')";
             if($conn->query($sql) === TRUE) {
                 $voteMessage = "You voted for KuCoin withdrawals being suspended!";
             } else {

--- a/index.php
+++ b/index.php
@@ -23,6 +23,7 @@
 
     $userIP = $_SERVER['REMOTE_ADDR'];
     $userIPHashed = password_hash($userIP, PASSWORD_DEFAULT);
+    $userIPHashedResult = password_verify($)
 
     // create connection
     $conn = mysqli_connect($host, $username, $password, $database);
@@ -32,9 +33,13 @@
         die("Connection to database failed.");
     }
 
+    // Get hashed password from database
+    $SQLHashedIP = "SELECT * FROM votes;";
+    $userIPHashedResult = password_verify($userIP, $SQLHashedIP['IP']);
+
     // Check POST methods to track votes
     if(isset($_POST['binancedown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -48,7 +53,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif (isset($_POST['binanceup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -62,7 +67,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -76,7 +81,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -90,7 +95,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavoup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -104,7 +109,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavodown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -118,7 +123,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandaup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -132,7 +137,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandadown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -146,7 +151,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -160,7 +165,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -174,7 +179,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -188,7 +193,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -202,7 +207,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoinup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -216,7 +221,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoindown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {

--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@
 
     $userIP = $_SERVER['REMOTE_ADDR'];
     $userIPHashed = password_hash($userIP, PASSWORD_DEFAULT);
-    $userIPHashedResult = password_verify($userIP, $userIPHashed);
+    $SQLHashResult = "SELECT * FROM votes;"
 
     // create connection
     $conn = mysqli_connect($host, $username, $password, $database);
@@ -32,6 +32,13 @@
     if($conn->connect_error) {
         die("Connection to database failed.");
     }
+
+    $resultIP = $conn->prepare($sql);
+    $resultIP->execute();
+
+    $query = $resultIP->fetch();
+
+    $userIPHashedResult = password_verify($userIP, $query['IP']);
 
     // Check POST methods to track votes
     if(isset($_POST['binancedown'])) {

--- a/index.php
+++ b/index.php
@@ -22,8 +22,9 @@
     $voteMessage = "";
 
     $userIP = $_SERVER['REMOTE_ADDR'];
-    $userIPHashed = password_hash($userIP, PASSWORD_DEFAULT);
-    $userIPHashedResult = password_verify($)
+    $IPSalt = "SALT"; // Change to set custom salt to protect IP addresses in case of database breach
+    $IPConcat = "$userIP$IPSalt";
+    $userIPHashed = md5($IPConcat);
 
     // create connection
     $conn = mysqli_connect($host, $username, $password, $database);
@@ -33,13 +34,9 @@
         die("Connection to database failed.");
     }
 
-    // Get hashed password from database
-    $SQLHashedIP = "SELECT * FROM votes;";
-    $userIPHashedResult = password_verify($userIP, $SQLHashedIP['IP']);
-
     // Check POST methods to track votes
     if(isset($_POST['binancedown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -53,7 +50,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif (isset($_POST['binanceup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -67,7 +64,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -81,7 +78,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -95,7 +92,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavoup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -109,7 +106,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavodown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -123,7 +120,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandaup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -137,7 +134,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandadown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -151,7 +148,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -165,7 +162,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -179,7 +176,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -193,7 +190,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -207,7 +204,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoinup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -221,7 +218,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoindown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@
         die("Connection to database failed.");
     }
 
-    $resultIP = $conn->prepare($sql);
+    $resultIP = $conn->prepare($SQLHashResult);
     $resultIP->execute();
 
     $query = $resultIP->fetch();

--- a/index.php
+++ b/index.php
@@ -23,7 +23,6 @@
 
     $userIP = $_SERVER['REMOTE_ADDR'];
     $userIPHashed = password_hash($userIP, PASSWORD_DEFAULT);
-    $SQLHashResult = "SELECT * FROM votes;"
 
     // create connection
     $conn = mysqli_connect($host, $username, $password, $database);
@@ -33,16 +32,9 @@
         die("Connection to database failed.");
     }
 
-    $resultIP = $conn->prepare($SQLHashResult);
-    $resultIP->execute();
-
-    $query = $resultIP->fetch();
-
-    $userIPHashedResult = password_verify($userIP, $query['IP']);
-
     // Check POST methods to track votes
     if(isset($_POST['binancedown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -56,7 +48,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif (isset($_POST['binanceup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 1";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 1";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -70,7 +62,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -84,7 +76,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitfinexdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 2";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 2";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -98,7 +90,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavoup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -112,7 +104,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitvavodown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 3";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 3";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -126,7 +118,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandaup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -140,7 +132,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['bitpandadown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 4";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 4";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -154,7 +146,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -168,7 +160,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['upbitdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 5";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 5";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -182,7 +174,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -196,7 +188,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['indodaxdown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 6";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 6";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -210,7 +202,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoinup'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {
@@ -224,7 +216,7 @@
             $voteMessage = "You already voted in the last 24 hours!";
         }
     } elseif(isset($_POST['kucoindown'])) {
-        $sql = "SELECT * FROM votes WHERE IP = $userIPHashedResult AND Exchange = 7";
+        $sql = "SELECT * FROM votes WHERE IP = $userIPHashed AND Exchange = 7";
         $result = mysqli_query($conn, $sql);
         $count = mysqli_num_rows($result);
         if($count == 0) {


### PR DESCRIPTION
- IP addresses are now being saved as a SHA256 hash in the database. Because IPv4 addresses are limited every hash should be known. Therefore, I added the variable $salt which you can change to add your fixed salt. The hashed value in the database therefore is "IP + SALT". This way the IP addresses don't get exposed in case the database get's hacked. -> Which also means no user specific data is saved more than 24 hours and all user specific data is protected trough a salted hash.
- Positioned the buttons to vote below the statistics and added a text to explain, that people can send their vote by pressing one of the buttons.
- Added the link to this GitHub repo to the footer